### PR TITLE
Move opm-spec-create to use jinja2 templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Provides tooling to create specs for puppet modules to be used in rdo.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+* Implement argparse:
+  * take review id to create spec for new module under review
+  * allow to specify where to check out upstream modules (besides tmp)
+  * allow to specifiy if using checked-out rdoinfo repo
+* Make structure class-based and more modular.
+* Extract common tasks to a base class, so there is option to have specific
+  child classes for different types of projects in future besides puppet.
+* Add tests
+* Add structure to allow beter packaging of this module.
+* Abstract out special cases of files that a given project needs (puppet-nova is
+  current example)
+* Make Source be a list and then iterate over it and name them accordingly
+  (Source0, Source1, etc.), like the metadata.dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 rdopkg
 six
+jinja2

--- a/templates/puppet.spec
+++ b/templates/puppet.spec
@@ -1,0 +1,52 @@
+%{!?upstream_version: %global upstream_version %{version}%{?milestone}}
+{% if metadata.from_puppetlabs -%}
+%%define upstream_name {{ metadata.project_name }}
+{% endif %}
+Name:                   {{ metadata.name }}
+Version:                XXX
+Release:                XXX
+Summary:                {{ metadata.summary }}
+License:                {{ metadata.license }}
+
+URL:                    {{ metadata.project_page }}
+
+Source0:                {{ metadata.source0 }}
+
+BuildArch:              noarch
+
+{% for dep in metadata.dependencies -%}
+Requires:               {{ dep.name }}
+{% endfor %}
+Requires:               puppet >= 2.7.0
+
+%description
+{{ metadata.description }}
+
+%prep
+%setup -q -n {{ '%{'+metadata.upstream_name+'}-%{upstream_version}' }}
+
+find . -type f -name ".*" -exec rm {} +
+find . -size 0 -exec rm {} +
+find . \( -name "*.pl" -o -name "*.sh"  \) -exec chmod +x {} +
+find . \( -name "*.pp" -o -name "*.py"  \) -exec chmod -x {} +
+find . \( -name "*.rb" -o -name "*.erb" \) -exec chmod -x {} +
+find . \( -name spec -o -name ext \) | xargs rm -rf
+
+%build
+
+
+%install
+rm -rf %{buildroot}
+install -d -m 0755 %{buildroot}/%{_datadir}/openstack-puppet/modules/{{ metadata.project }}/
+cp -rp * %{buildroot}/%{_datadir}/openstack-puppet/modules/{{ metadata.project }}/
+{% if "nova" == metadata.project -%}
+rm -f %{buildroot}/%{_datadir}/openstack-puppet/modules/nova/files/nova-novncproxy.init
+{%- endif %}
+
+
+%files
+%{_datadir}/openstack-puppet/modules/{{ metadata.project }}/
+
+
+%changelog
+


### PR DESCRIPTION
This patch contains a begining of some major rework in code structure
with the goal of creating (and potentially updating) specs that are
more compliant with rdo process, and extracting the generation logic
out of the code itself into templates.
