### PR TITLE
Do not "rm -rf %{buildroot}" at the beginning of the %install section

### DIFF
--- a/templates/puppet.spec
+++ b/templates/puppet.spec
@@ -36,7 +36,6 @@ find . \( -name spec -o -name ext \) | xargs rm -rf
 
 
 %install
-rm -rf %{buildroot}
 install -d -m 0755 %{buildroot}/%{_datadir}/openstack-puppet/modules/{{ metadata.project }}/
 cp -rp * %{buildroot}/%{_datadir}/openstack-puppet/modules/{{ metadata.project }}/
 {% if "nova" == metadata.project -%}


### PR DESCRIPTION
fedora-review advises against it, so let's follow its recommendation.